### PR TITLE
Update 04_create_serving_endpoint.py

### DIFF
--- a/src/setup/notebooks/notebooks/ml/04_create_serving_endpoint.py
+++ b/src/setup/notebooks/notebooks/ml/04_create_serving_endpoint.py
@@ -5,7 +5,7 @@ print(f'catalog = {catalog}')
 
 # COMMAND ----------
 
-# MAGIC %pip install mlflow
+# MAGIC %pip install mlflow typing_extensions==4.11.0
 
 # COMMAND ----------
 


### PR DESCRIPTION
Description: `create_serving_endpoint` fails with current version of typing_extensions returning message `cannot import name 'Deprecated' from 'typing_extensions'`

**Resolution Attempt 1:**
* [This GitHub Discussion](https://github.com/fastapi/fastapi/discussions/9808#discussioncomment-6920022) suggested using `typing_extensions==4.7.1` to resolve error
* Using`%pip install typing_extensions==4.7.1` resulted in `cannot import name 'TypeIs' from 'typing_extensions'`

**Successful Attempt 2:**
* [This GitHub Discussion](https://github.com/AbdBarho/stable-diffusion-webui-docker/issues/719) suggested using `typing_extensions==4.11.0` to resolve error
* Using`%pip install typing_extensions==4.11.1` resulted in successful completion of task