### PR TITLE
Update create_sql_warehouse.py

### DIFF
--- a/src/setup/notebooks/notebooks/create_sql_warehouse.py
+++ b/src/setup/notebooks/notebooks/create_sql_warehouse.py
@@ -27,6 +27,7 @@ try:
         cluster_size="Small",
         max_num_clusters=5,
         auto_stop_mins=10,
+        enable_serverless_compute=True,
         tags=sql.EndpointTags(
             custom_tags=[sql.EndpointTagPair(key="Owner", value=f'{user_name}')
                         ])).result()


### PR DESCRIPTION
Description: Currently `create_sql_warehouse` results in creation of a classic cluster. Adding `enable_serverless_compute=True` per [databricks-sdk-py docs](https://databricks-sdk-py.readthedocs.io/en/latest/workspace/sql/warehouses.html) create a serverless warehouse instead.